### PR TITLE
second judge UI: show as a flag (kept), not a removal

### DIFF
--- a/src/components/JobCard.tsx
+++ b/src/components/JobCard.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect, useRef} from 'react';
-import { Calendar, Sparkles, ShieldCheck, ShieldX, ShieldQuestion } from 'lucide-react';
+import { Calendar, Sparkles, ShieldCheck, ShieldAlert, ShieldQuestion } from 'lucide-react';
 import { Job } from '../types';
 import { getTimeAgo } from '../utils/getTimeAgo';
 import { useDownloadHighlightStore } from '../state_management/DownloadHighlightStore.ts';
@@ -166,7 +166,7 @@ const JobCard: React.FC<JobCardProps> = ({
               <ShieldCheck className="w-3.5 h-3.5 text-green-600 flex-shrink-0" title={`Second-stage screening passed${sjScoreLabel}`} />
             )}
             {sjFailed && (
-              <ShieldX className="w-3.5 h-3.5 text-red-600 flex-shrink-0" title={`Failed second-stage screening${sjScoreLabel}`} />
+              <ShieldAlert className="w-3.5 h-3.5 text-amber-600 flex-shrink-0" title={`Flagged in second-stage screening${sjScoreLabel} — review`} />
             )}
             {(sjPending || sjProcessing) && (
               <ShieldQuestion className="w-3.5 h-3.5 text-blue-500 flex-shrink-0 animate-pulse" title="Second-stage screening in progress" />
@@ -244,8 +244,8 @@ const JobCard: React.FC<JobCardProps> = ({
             <p className="text-xs font-medium text-green-600">Second-stage screening passed{sjScoreLabel}.</p>
           )}
           {sjFailed && (
-            <p className="text-xs font-medium text-red-600">
-              Failed second-stage screening{sjScoreLabel}{sjReason ? ` — ${sjReason}` : ''}.
+            <p className="text-xs font-medium text-amber-700">
+              ⚠️ AI flag{sjScoreLabel}{sjReason ? ` — ${sjReason}` : ''}. Kept — review and decide.
             </p>
           )}
           {sjPending && (

--- a/src/components/JobModal.tsx
+++ b/src/components/JobModal.tsx
@@ -2006,7 +2006,7 @@ export default function JobModal({
                                                 {jobDetails.secondJudge.status === 'passed'
                                                     ? `Passed${jobDetails.secondJudge.score != null ? ` (score ${jobDetails.secondJudge.score})` : ''} — matched the client profile on the real posting.`
                                                     : jobDetails.secondJudge.status === 'failed'
-                                                        ? `Failed${jobDetails.secondJudge.score != null ? ` (score ${jobDetails.secondJudge.score})` : ''}${jobDetails.secondJudge.reason ? ` — ${jobDetails.secondJudge.reason}` : ''}. Moved to removed.`
+                                                        ? `⚠️ Flagged for review${jobDetails.secondJudge.score != null ? ` (score ${jobDetails.secondJudge.score})` : ''}${jobDetails.secondJudge.reason ? ` — ${jobDetails.secondJudge.reason}` : ''}. Kept — your call whether to remove.`
                                                         : jobDetails.secondJudge.status === 'processing'
                                                             ? 'Opening the employer site and re-judging…'
                                                             : jobDetails.secondJudge.status === 'skipped'


### PR DESCRIPTION
JobCard shows an amber ShieldAlert + 'AI flag — review and decide' for ops; JobModal timeline reads 'Flagged for review … Kept — your call', not 'moved to removed'. The job stays in its column.