### PR TITLE
JobModal: show the resolved reason for 'reviewed' second-stage jobs

### DIFF
--- a/src/components/JobModal.tsx
+++ b/src/components/JobModal.tsx
@@ -2011,9 +2011,11 @@ export default function JobModal({
                                                             ? 'Opening the employer site and re-judging…'
                                                             : jobDetails.secondJudge.status === 'skipped'
                                                                 ? (jobDetails.secondJudge.reason || 'The second-stage check could not be completed — job kept.')
-                                                                : (jobDetails.secondJudge.status === 'pending' && (jobDetails.secondJudge.attempts ?? 0) > 0 && jobDetails.secondJudge.error)
-                                                                    ? `Paused after a temporary error opening the posting — retrying automatically (attempt ${jobDetails.secondJudge.attempts}). Backoff grows to several hours before it gives up and keeps the job.`
-                                                                    : 'Queued for second-stage screening.'}
+                                                                : jobDetails.secondJudge.status === 'reviewed'
+                                                                    ? (jobDetails.secondJudge.reason || 'The second-stage flag has been resolved.')
+                                                                    : (jobDetails.secondJudge.status === 'pending' && (jobDetails.secondJudge.attempts ?? 0) > 0 && jobDetails.secondJudge.error)
+                                                                        ? `Paused after a temporary error opening the posting — retrying automatically (attempt ${jobDetails.secondJudge.attempts}). Backoff grows to several hours before it gives up and keeps the job.`
+                                                                        : 'Queued for second-stage screening.'}
                                             </p>
                                         </li>
                                     )}


### PR DESCRIPTION
A job the AI auto-removed as expired (or an operator resolved) has secondJudge.status 'reviewed', which fell through to the default branch and rendered 'Queued for second-stage screening.' on an already-removed job.