### PR TITLE
Login resilience, password-manager guard for ops accounts, Discord removal webhook via env

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -339,6 +339,7 @@ import { useUserProfile } from "../state_management/ProfileContext"
 import { useOperationsStore } from "../state_management/Operations"
 import { toastUtils, toastMessages } from "../utils/toast"
 import { shouldHidePasswordFromManager, guardedPasswordInputProps } from "../utils/passwordManagerGuard"
+import { postJsonWithRetry } from "../utils/postJson"
 import { GoogleLogin } from "@react-oauth/google"
 
 interface LoginResponse {
@@ -538,12 +539,10 @@ export default function Login() {
     try {
       const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
       const loginEndpoint = normalizedEmail.includes("@flashfirehq") ? "/operations/login" : "/login"
-      const res = await fetch(`${API_BASE_URL}${loginEndpoint}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: normalizedEmail, password }),
-      })
-      const data: LoginResponse = await res.json()
+      const { data } = await postJsonWithRetry<LoginResponse>(
+        `${API_BASE_URL}${loginEndpoint}`,
+        { email: normalizedEmail, password },
+      )
       setResponse(data)
 
       if (loginEndpoint === "/operations/login") {
@@ -900,12 +899,10 @@ export default function Login() {
       onSuccess={async (credentialResponse) => {
         const loadingToast = toastUtils.loading(toastMessages.loggingIn)
         try {
-          const res = await fetch(`${import.meta.env.VITE_API_BASE_URL}/google-oauth`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ token: credentialResponse.credential }),
-          })
-          const data = await res.json()
+          const { data } = await postJsonWithRetry<LoginResponse>(
+            `${import.meta.env.VITE_API_BASE_URL}/google-oauth`,
+            { token: credentialResponse.credential },
+          )
 
           if (data?.message === "User not found") {
             toastUtils.dismissToast(loadingToast)

--- a/src/utils/postJson.ts
+++ b/src/utils/postJson.ts
@@ -1,0 +1,45 @@
+export interface PostJsonResult<T> {
+    ok: boolean
+    status: number
+    data: T | null
+}
+
+// Auth calls go through Cloudflare + Render; a deploy or a brief origin hiccup
+// returns a 502/524 HTML page, and flaky client networks make fetch itself
+// throw. Both used to surface instantly as "Network error" toasts. Retry a
+// couple of times with backoff so one-second blips never fail a login, and
+// parse JSON defensively so an HTML error page can't crash the flow.
+export async function postJsonWithRetry<T = unknown>(
+    url: string,
+    body: unknown,
+    retries = 2,
+): Promise<PostJsonResult<T>> {
+    let lastError: unknown = null
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        if (attempt > 0) {
+            await new Promise((resolve) => setTimeout(resolve, attempt * 1500))
+        }
+        try {
+            const res = await fetch(url, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(body),
+            })
+            if (res.status >= 500 && attempt < retries) {
+                continue
+            }
+            let data: T | null = null
+            try {
+                data = (await res.json()) as T
+            } catch {
+                if (attempt < retries) {
+                    continue
+                }
+            }
+            return { ok: res.ok, status: res.status, data }
+        } catch (err) {
+            lastError = err
+        }
+    }
+    throw lastError instanceof Error ? lastError : new Error("Network request failed")
+}


### PR DESCRIPTION
## Highlights

### Fix: intermittent "Network error" on client logins
- New `src/utils/postJson.ts`: credential login and Google OAuth go through `postJsonWithRetry` — up to 2 retries with backoff on network failures and 5xx responses, plus defensive JSON parsing so a transient Cloudflare/Render HTML error page no longer fails a login instantly.

### Keep @flashfirehq credentials out of Google Password Manager
- New `src/utils/passwordManagerGuard.ts`: internal logins render the password box as a CSS-masked text input, so the browser never sees a savable credential. Hidden by default on page load; flips to a real password field only once the typed domain is clearly a client's — client save/autofill is unaffected.
- Applied across both logins, both registrations, admin add-user, and all secret/session/unlock key modals.
- Note: already-saved entries must still be deleted manually from the shared profile's password manager.

### Discord notification for client job-card removals
- Webhook URL moved from hardcoded to `VITE_DISCORD_REMOVED_WEBHOOK_URL` (set it in the hosting platform's env — .env is gitignored).

Also clears pre-existing lint debt in every touched file. eslint, tsc, and production build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)