### PR TITLE
Alert Discord when a client hits a network error on login

### DIFF
--- a/env.example
+++ b/env.example
@@ -26,3 +26,6 @@ VITE_ENABLE_ERROR_TRACKING=true
 
 # Discord webhook notified when a client moves a job card to Removed
 VITE_DISCORD_REMOVED_WEBHOOK_URL=your-discord-webhook-url
+
+# Discord webhook alerted when a client hits a network error on login
+VITE_DISCORD_NETWORK_ERROR_WEBHOOK_URL=your-discord-webhook-url

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -340,6 +340,7 @@ import { useOperationsStore } from "../state_management/Operations"
 import { toastUtils, toastMessages } from "../utils/toast"
 import { shouldHidePasswordFromManager, guardedPasswordInputProps } from "../utils/passwordManagerGuard"
 import { postJsonWithRetry } from "../utils/postJson"
+import { reportNetworkError } from "../utils/reportNetworkError"
 import { GoogleLogin } from "@react-oauth/google"
 
 interface LoginResponse {
@@ -536,9 +537,9 @@ export default function Login() {
 
     setIsLoading(true)
     const loadingToast = toastUtils.loading(toastMessages.loggingIn)
+    const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
+    const loginEndpoint = normalizedEmail.includes("@flashfirehq") ? "/operations/login" : "/login"
     try {
-      const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
-      const loginEndpoint = normalizedEmail.includes("@flashfirehq") ? "/operations/login" : "/login"
       const { data } = await postJsonWithRetry<LoginResponse>(
         `${API_BASE_URL}${loginEndpoint}`,
         { email: normalizedEmail, password },
@@ -645,6 +646,7 @@ export default function Login() {
       }
     } catch (err) {
       console.error(err)
+      reportNetworkError("Login", normalizedEmail, err, `${API_BASE_URL}${loginEndpoint}`)
       toastUtils.dismissToast(loadingToast)
       toastUtils.error(toastMessages.networkError)
     } finally {
@@ -943,6 +945,7 @@ export default function Login() {
           }
         } catch (err) {
           console.error(err)
+          reportNetworkError("Google OAuth", "", err, `${import.meta.env.VITE_API_BASE_URL}/google-oauth`)
           toastUtils.dismissToast(loadingToast)
           toastUtils.error(toastMessages.networkError)
         }

--- a/src/utils/reportNetworkError.ts
+++ b/src/utils/reportNetworkError.ts
@@ -1,0 +1,55 @@
+const WEBHOOK_URL = import.meta.env.VITE_DISCORD_NETWORK_ERROR_WEBHOOK_URL
+
+let lastReportAt = 0
+
+// Fire-and-forget Discord alert when a client hits a network-level failure.
+// Discord is a different host than the API, so this usually still delivers
+// when the backend is unreachable — and "Browser online: yes" tells us the
+// problem was on our side, not the client's connection. Throttled so a retry
+// loop can't flood the channel; never throws back into the calling flow.
+export function reportNetworkError(
+    context: string,
+    clientEmail: string,
+    error: unknown,
+    endpoint?: string,
+): void {
+    if (!WEBHOOK_URL) return
+    const now = Date.now()
+    if (now - lastReportAt < 20000) return
+    lastReportAt = now
+
+    const message = error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+    const payload = {
+        embeds: [
+            {
+                title: "Client Network Error",
+                color: 0xdc2626,
+                fields: [
+                    { name: "Where", value: context, inline: true },
+                    { name: "Client", value: clientEmail || "unknown", inline: true },
+                    {
+                        name: "Browser online",
+                        value: typeof navigator !== "undefined" && navigator.onLine ? "yes" : "no",
+                        inline: true,
+                    },
+                    { name: "Error", value: message.slice(0, 1000) || "unknown", inline: false },
+                    ...(endpoint ? [{ name: "Endpoint", value: endpoint, inline: false }] : []),
+                    {
+                        name: "User agent",
+                        value: (typeof navigator !== "undefined" ? navigator.userAgent : "unknown").slice(0, 300),
+                        inline: false,
+                    },
+                ],
+                timestamp: new Date().toISOString(),
+            },
+        ],
+    }
+
+    fetch(WEBHOOK_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+    }).catch(() => {
+        // Reporting must never surface its own failures.
+    })
+}


### PR DESCRIPTION
New VITE_DISCORD_NETWORK_ERROR_WEBHOOK_URL env. Both credential login and Google OAuth catch blocks post an embed with the client email, where it failed, the exact error, endpoint, browser online status and user agent. Throttled to one report per 20s, fire-and-forget so reporting can never break the login flow.