### PR TITLE
Make the whole "Continue with Google" button clickable

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -705,12 +705,24 @@ export default function Login() {
         {/* Google Login Button */}
         <div className="group relative w-full h-11 mb-6" id="google-button-wrapper">
           <style>{`
-            #google-button-wrapper > div:first-child {
+            /* Stretch Google's button to the full width of the visual one.
+               Google hard-caps its widget at 400px, so every wrapper it
+               renders - and the button itself - has to be overridden, or the
+               clickable area is narrower than what the user sees and a click
+               on the centre label hits nothing. Targeted by id and by
+               role="button" rather than Google's generated class names, which
+               change without notice. */
+            #google-gsi-host,
+            #google-gsi-host > div,
+            #google-gsi-host > div > div,
+            #google-gsi-host > div > div > div,
+            #google-gsi-host iframe {
               width: 100% !important;
+              max-width: 100% !important;
             }
-            #google-button-wrapper > div:first-child > div,
-            #google-button-wrapper > div:first-child iframe {
+            #google-gsi-host [role="button"] {
               width: 100% !important;
+              max-width: 100% !important;
             }
           `}</style>
 
@@ -726,7 +738,7 @@ export default function Login() {
           </div>
 
           {/* Real Google button, rendered transparent and stretched to fill the container so clicks land on it */}
-          <div className="absolute inset-0 overflow-hidden opacity-0">
+          <div id="google-gsi-host" className="absolute inset-0 overflow-hidden opacity-0">
           <GoogleLogin
             key={`google-login-button-${googleButtonKey}`}
             theme="outline"


### PR DESCRIPTION
Clicking the button did nothing. The visual button is a decorative pointer-events-none div, with Google's real button rendered invisible on top of it, so the real one has to cover the same area or clicks land on nothing.

It did not. The CSS meant to stretch it read:

    #google-button-wrapper > div:first-child { width: 100% !important; }

but the first child of that wrapper is the <style> element itself, so `div:first-child` matched nothing and the rule never applied. Google caps its widget at 400px, so the real button stayed 400px wide inside a full-width visual one. Measured in the browser at a 1006px viewport: visible button 911px, real button 400px. Probing along the centre line, only the left 400px was live - the centre, where the label sits and where people actually click, hit a bare div.

Fixed by giving the host an id instead of relying on child position, and overriding width and max-width on Google's wrapper chain and on the button itself. The button is matched by [role="button"] rather than its generated class names, which change without notice.

Verified across breakpoints - visible and real widths now match and every point across the button is clickable:

  1006px viewport -> 911px / 911px
  1440px viewport -> 392px / 392px
   390px viewport -> 327px / 327px