### PR TITLE
JobModal: fall back to the job's owner email, and say what is missing

### DIFF
--- a/src/components/JobModal.tsx
+++ b/src/components/JobModal.tsx
@@ -900,10 +900,15 @@ export default function JobModal({
         if (!pastedImages.length) return;
 
         const jobID = jobDetails?.jobID;
-        const userEmail = currentUser?.email;
+        // Fall back to the job's own owner email. A session that lost its
+        // email would otherwise block this outright; the modal already
+        // falls back to userID when displaying the account.
+        const userEmail = currentUser?.email || jobDetails?.userID;
         if (!jobID || !userEmail) {
             setPasteError(
-                "Missing jobID or user email; cannot save attachments."
+                !jobID
+                    ? "This job has no ID yet. Close and reopen it from the tracker, then try again."
+                    : "Your session is missing an email address. Please sign out and sign back in."
             );
             return;
         }
@@ -984,9 +989,16 @@ export default function JobModal({
         if (!imgFile) return;
 
         const jobID = jobDetails?.jobID;
-        const userEmail = currentUser?.email;
+        // Fall back to the job's own owner email. A session that lost its
+        // email would otherwise block this outright; the modal already
+        // falls back to userID when displaying the account.
+        const userEmail = currentUser?.email || jobDetails?.userID;
         if (!jobID || !userEmail) {
-            setImgError("Missing jobID or user email; cannot save attachment.");
+            setImgError(
+                !jobID
+                    ? "This job has no ID yet. Close and reopen it from the tracker, then try again."
+                    : "Your session is missing an email address. Please sign out and sign back in."
+            );
             console.error("[handleImgUpload] Missing identifiers", {
                 jobID,
                 userEmail,
@@ -1074,10 +1086,15 @@ export default function JobModal({
         if (!file) return;
 
         const jobID = jobDetails?.jobID;
-        const userEmail = currentUser?.email;
+        // Fall back to the job's own owner email. A session that lost its
+        // email would otherwise block this outright; the modal already
+        // falls back to userID when displaying the account.
+        const userEmail = currentUser?.email || jobDetails?.userID;
         if (!jobID || !userEmail) {
             setDocError(
-                "Missing jobID or user email; cannot add optimized resume."
+                !jobID
+                    ? "This job has no ID yet. Close and reopen it from the tracker, then try again."
+                    : "Your session is missing an email address. Please sign out and sign back in."
             );
             console.error("[handleDocFileChange] Missing identifiers", {
                 jobID,
@@ -2095,7 +2112,10 @@ export default function JobModal({
 
         try {
             // Get user email - for operations, get from currentUser (the client whose job this is)
-            const userEmail = currentUser?.email;
+            // Fall back to the job's own owner email. A session that lost its
+            // email would otherwise block this outright; the modal already
+            // falls back to userID when displaying the account.
+            const userEmail = currentUser?.email || jobDetails?.userID;
 
             if (!userEmail) {
                 // toastUtils.error("User email not found. Cannot optimize resume.");
@@ -2545,7 +2565,10 @@ export default function JobModal({
                                         onClick={async () => {
                                             try {
                                                 // Get user email - for operations, get from currentUser (the client whose job this is)
-                                                const userEmail = currentUser?.email;
+                                                // Fall back to the job's own owner email. A session that lost its
+                                                // email would otherwise block this outright; the modal already
+                                                // falls back to userID when displaying the account.
+                                                const userEmail = currentUser?.email || jobDetails?.userID;
 
                                                 if (!userEmail) {
                                                     toastUtils.error("User email not found. Cannot optimize resume.");


### PR DESCRIPTION
"Missing jobID or user email; cannot save attachments" is still reaching users. The backend half of the session fix is live - /get-updated-user now 404s on a miss instead of returning 200 with an empty body - so no new sessions are being wiped. But the frontend half is not deployed, so browsers whose stored session was already clobbered stay broken, and only clearing site data recovers them.

Two changes so the modal copes on its own:

- Every place that needed the signed-in email now falls back to jobDetails.userID, which is the job's own owner email. The modal already did this when displaying the account; the five handlers that actually use the address did not. That covers both attachment uploads and the two Optimize flows, which failed the same way with "User email not found".

- The three attachment errors said "Missing jobID or user email" without saying which, so there was nothing to act on. They now distinguish a job with no ID (reopen it from the tracker) from a session with no email (sign out and back in).

This does not replace the session fix in 4be5a5c - that still needs deploying so affected browsers heal instead of relying on this fallback.