### PR TITLE
Add UK visa status options to onboarding form

### DIFF
--- a/src/components/NewUserModal.tsx
+++ b/src/components/NewUserModal.tsx
@@ -1571,7 +1571,7 @@ const initialData: FormData = {
   referredBy: '',              // optional
 };
 
-const VISA_OPTIONS = ["CPT", "F1", "F1 OPT", "F1 STEM OPT", "H1B", "Green Card", "U.S. Citizen", "Canadian Citizen", "Permanent Resident (PR)", "Post-Graduation Work Permit (PGWP)", "Open Work Permit (OWP)", "Employer-Specific (Closed) Work Permit", "Study Permit", "Other"];
+const VISA_OPTIONS = ["CPT", "F1", "F1 OPT", "F1 STEM OPT", "H1B", "Green Card", "U.S. Citizen", "Canadian Citizen", "Permanent Resident (PR)", "Post-Graduation Work Permit (PGWP)", "Open Work Permit (OWP)", "Employer-Specific (Closed) Work Permit", "Study Permit", "Student Visa", "Short-term Study Visa", "Graduate Visa", "Skilled Worker Visa", "Global Talent Visa", "Other"];
 const EXPERIENCE_OPTIONS = ["0-2 Years", "2-4 Years", "4-6 Years", "6-8 Years", "8+ Years"];
 const SALARY_OPTIONS = ["60k-100k", "100k-150k", "150k-200k", "Other"];
 const EMPLOYMENT_TYPE_OPTIONS = ["Full-time", "Part-time", "Contract", "Internship"] as const;

--- a/src/state_management/ProfileContext.tsx
+++ b/src/state_management/ProfileContext.tsx
@@ -308,6 +308,17 @@ export interface UserProfile {
     | "H1B"
     | "Green Card"
     | "U.S. Citizen"
+    | "Canadian Citizen"
+    | "Permanent Resident (PR)"
+    | "Post-Graduation Work Permit (PGWP)"
+    | "Open Work Permit (OWP)"
+    | "Employer-Specific (Closed) Work Permit"
+    | "Study Permit"
+    | "Student Visa"
+    | "Short-term Study Visa"
+    | "Graduate Visa"
+    | "Skilled Worker Visa"
+    | "Global Talent Visa"
     | "Other";
 
   // Address


### PR DESCRIPTION
## Summary
- Adds five UK visa types to the "Current Visa Status" dropdown in the client onboarding modal (`NewUserModal.tsx`): Student Visa, Short-term Study Visa, Graduate Visa, Skilled Worker Visa, Global Talent Visa.
- Widens the `visaStatus` union type in `ProfileContext.tsx` to include these plus the Canadian options the dropdown already had but the type was missing.
- Companion backend PR updates the Mongoose `enum` on `ProfileModel.visaStatus` so these values validate and save — **merge that one first** or submissions with the new values will fail server-side validation until it lands.

## Test plan
- [ ] Open the onboarding form, confirm the 5 new options appear in the Visa Status dropdown.
- [ ] Select each new option, submit the form, confirm it saves without a validation error (requires the backend PR merged).
- [ ] Confirm the saved value round-trips correctly to the Profile page.
- [ ] `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)