### PR TITLE
Show Certifications card in edit-view section list  fallback

### DIFF
--- a/src/components/AiOprimizer/Optimizer.tsx
+++ b/src/components/AiOprimizer/Optimizer.tsx
@@ -2803,6 +2803,14 @@ function App() {
                                             })),
                                         ];
                                         const order = sectionOrder.filter((id) => id !== "personalInfo");
+                                        // A resume saved before certifications existed has no
+                                        // "certifications" in its stored order, so the toggle card
+                                        // would never render. Surface it next to publications.
+                                        if (!order.includes("certifications")) {
+                                            const pubIdx = order.indexOf("publications");
+                                            if (pubIdx >= 0) order.splice(pubIdx + 1, 0, "certifications");
+                                            else order.push("certifications");
+                                        }
                                         const ordered = order
                                             .map((id) => definitions.find((d) => d.id === id))
                                             .filter(Boolean) as any[];


### PR DESCRIPTION
The deployed build injected "certifications" into the section order only in the optimized-view render path, so resumes opened in the direct-edit view never showed the Certifications toggle card. Add the same injection to the edit-view path so every resume's editor surfaces it, regardless of which view it opens in or when it was last saved.