### PR TITLE
Certifications: render title at normal weight, not bold

### DIFF
--- a/src/components/AiOprimizer/components/ResumePreview.tsx
+++ b/src/components/AiOprimizer/components/ResumePreview.tsx
@@ -2025,7 +2025,7 @@ Tip: If the PDF shows extra pages, reduce the scale slightly and try again.`);
                                     <div
                                         style={{
                                             fontSize: styles.fontSize,
-                                            fontWeight: "bold",
+                                            fontWeight: "normal",
                                             letterSpacing: "-0.025em",
                                             lineHeight: styles.lineHeight,
                                             flex: "1",

--- a/src/components/AiOprimizer/components/ResumePreviewMedical.tsx
+++ b/src/components/AiOprimizer/components/ResumePreviewMedical.tsx
@@ -915,7 +915,7 @@ export const ResumePreviewMedical: React.FC<ResumePreviewProps> = ({
                                     <div
                                         style={{
                                             fontSize: "9pt",
-                                            fontWeight: "bold",
+                                            fontWeight: "normal",
                                             lineHeight: "1.3",
                                             flex: "1",
                                         }}


### PR DESCRIPTION
Both previews showed the certification title bold; make it normal weight (date stays bold on the right, issuer already normal) per request. Applies to normal and medical templates.