### PR TITLE
Certifications: support **bold** markers in title, date, issuer

### DIFF
--- a/src/components/AiOprimizer/components/ResumePreview.tsx
+++ b/src/components/AiOprimizer/components/ResumePreview.tsx
@@ -2031,7 +2031,7 @@ Tip: If the PDF shows extra pages, reduce the scale slightly and try again.`);
                                             flex: "1",
                                         }}
                                     >
-                                        {cert.title}
+                                        {renderMarkedText(cert.title)}
                                     </div>
                                     {cert.date && (
                                         <div
@@ -2045,7 +2045,7 @@ Tip: If the PDF shows extra pages, reduce the scale slightly and try again.`);
                                                 whiteSpace: "nowrap",
                                             }}
                                         >
-                                            {cert.date}
+                                            {renderMarkedText(cert.date)}
                                         </div>
                                     )}
                                 </div>
@@ -2058,7 +2058,7 @@ Tip: If the PDF shows extra pages, reduce the scale slightly and try again.`);
                                             lineHeight: styles.lineHeight,
                                         }}
                                     >
-                                        {cert.issuer}
+                                        {renderMarkedText(cert.issuer)}
                                     </div>
                                 )}
                             </div>

--- a/src/components/AiOprimizer/components/ResumePreviewMedical.tsx
+++ b/src/components/AiOprimizer/components/ResumePreviewMedical.tsx
@@ -920,7 +920,7 @@ export const ResumePreviewMedical: React.FC<ResumePreviewProps> = ({
                                             flex: "1",
                                         }}
                                     >
-                                        {cert.title}
+                                        {renderMarkedText(cert.title)}
                                     </div>
                                     {cert.date && (
                                         <div
@@ -933,7 +933,7 @@ export const ResumePreviewMedical: React.FC<ResumePreviewProps> = ({
                                                 whiteSpace: "nowrap",
                                             }}
                                         >
-                                            {cert.date}
+                                            {renderMarkedText(cert.date)}
                                         </div>
                                     )}
                                 </div>
@@ -944,7 +944,7 @@ export const ResumePreviewMedical: React.FC<ResumePreviewProps> = ({
                                             lineHeight: "1.3",
                                         }}
                                     >
-                                        {cert.issuer}
+                                        {renderMarkedText(cert.issuer)}
                                     </div>
                                 )}
                             </div>


### PR DESCRIPTION
Render certification fields through renderMarkedText so an operator can bold any part with **x**, matching every other section. Applies to normal and medical previews.